### PR TITLE
replace projectRoot with watchFolders

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -76,8 +76,8 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: "packages/mobile/index.js",
-    root: "../../../../",
+    entryFile: "index.js",
+    root: "../../",
     enableHermes: false,  // clean and rebuild if changing
 ]
 

--- a/packages/mobile/android/app/src/main/java/com/myprojectname/MainApplication.java
+++ b/packages/mobile/android/app/src/main/java/com/myprojectname/MainApplication.java
@@ -30,7 +30,7 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override
         protected String getJSMainModuleName() {
-          return "packages/mobile/index";
+          return "index";
         }
       };
 

--- a/packages/mobile/ios/myprojectname.xcodeproj/project.pbxproj
+++ b/packages/mobile/ios/myprojectname.xcodeproj/project.pbxproj
@@ -371,7 +371,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\nexport EXTRA_PACKAGER_ARGS=\"--entry-file packages/mobile/index.js\"\n../../../node_modules/react-native/scripts/react-native-xcode.sh\n";
+			shellScript = "export NODE_BINARY=node\nexport EXTRA_PACKAGER_ARGS=\"--entry-file index.js\"\n../../../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/mobile/ios/myprojectname/AppDelegate.m
+++ b/packages/mobile/ios/myprojectname/AppDelegate.m
@@ -33,7 +33,7 @@
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
 #if DEBUG
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"packages/mobile/index" fallbackResource:nil];
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -8,7 +8,7 @@
 const path = require('path');
 
 module.exports = {
-  projectRoot: path.resolve(__dirname, '../../'),
+  watchFolders: [path.resolve(__dirname, '../../')],
   transformer: {
     getTransformOptions: async () => ({
       transform: {


### PR DESCRIPTION
No need to make a `root: ../../../../`, we can just add a `watchFolders`
field instead.

fixes #44