### PR TITLE
Fix android .gradle path errors

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -208,4 +208,4 @@ task copyDownloadableDepsToLibs(type: Copy) {
     into 'libs'
 }
 
-apply from: file("../../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project, "../../..")
+apply from: file("../../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/packages/mobile/android/settings.gradle
+++ b/packages/mobile/android/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'myprojectname'
-apply from: file("../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings, "../../..")
+apply from: file("../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'


### PR DESCRIPTION
User attempts to start the android application via `yarn android` fail because `applyNativeModulesAppBuildGradle()` no longer requires the path argument.

This pull request removes the argument in the two files `applyNativeModulesAppBuildGradle` is used - `packages/mobile/android/settings.gradle` and `packages/mobile/android/app/build.gradle` which removes errors on macOS Catalina 10.15.3 