### PR TITLE
fix: extends getApplication in @types/react-native

### DIFF
--- a/packages/web-nextjs/@types/react-native.d.ts
+++ b/packages/web-nextjs/@types/react-native.d.ts
@@ -1,3 +1,5 @@
+import * as ReactNative from 'react-native'
+
 declare module 'react-native' {
   namespace AppRegistry {
     function registerComponent(


### PR DESCRIPTION
this PR is to address the build issue after upgraded next.js to version 10.x

1. https://github.com/brunolemos/react-native-web-monorepo/issues/69
2. https://github.com/martpie/next-transpile-modules/issues/101#issuecomment-791978252